### PR TITLE
Fixes to esp32_secopPower.cpp

### DIFF
--- a/lib/secopPower/esp32_secopPower.cpp
+++ b/lib/secopPower/esp32_secopPower.cpp
@@ -4,17 +4,19 @@
 // ESP32s have ledc PWM which allows setting the frequency, so will use that.
 
 void SecopPower::begin() {
-    ledcSetup(1, 5000, 10);
-    pinMode(pin, OUTPUT);
-    ledcAttachPin(pin, 1);
-    ledcWrite(1, config->dutyOff);
-}
+    // ledcAttachPin changed  so needed change and remove ledcSetup  JEM 2024-06
+    // through out pin is  changed to PWM_PIN as that is what is used in ledcAttach and ledcWrite JEM 2024-06
+    // class variable pin is not used Could assign to PWM_PIN and other refernces to pin JEM 2024-06
+    ledcAttach(PWM_PIN, 5000, 10);
+    //pinMode(pin, OUTPUT); Conflictes with ledcAttachPin, so removed JEM 2024-06
+    //ledcAttachPin(pin, 1); Not needed as ledcAttach does this JEM 2024-06
+    ledcWrite(PWM_PIN, config->dutyOff);}
 int16_t SecopPower::getCompressorRPM() {
   return compressorRPM;
 }
 
 void SecopPower::setDutyCycle(int16_t duty) {
-    ledcWrite(1, duty);
+    ledcWrite(PWM_PIN, duty);
     if ( duty == 0 ) {
       compressorRPM = 0;
     }
@@ -26,13 +28,13 @@ void SecopPower::setCompressorSpeed(int16_t rpm) {
  if ( rpm <  2000 ) {
     // effectively off
     compressorRPM = 0;
-    ledcWrite(1, config->dutyOff);
+    ledcWrite(PWM_PIN, config->dutyOff);
   } else if (rpm > 3500 ) {
     compressorRPM = 3500;
-    ledcWrite(1, config->duty3500);
+    ledcWrite(PWM_PIN, config->duty3500);
   } else {
     // assuming the relationship is linear
-    ledcWrite(1, map(rpm, 2000, 3500, config->duty2000, config->duty3500));
+    ledcWrite(PWM_PIN, map(rpm, 2000, 3500, config->duty2000, config->duty3500));
     compressorRPM = rpm;
   }
 }


### PR DESCRIPTION
My first attempt at pull request so could be doing this wrong.
A change in ledc library required changes and set pin with PWM_PIN.
Could set object variable pin to PWM_PIN in Begin and make the other needed changes.
If you prefer that reject and let me know.